### PR TITLE
 [fix][doc] auth problem in getting-started-docker-compose.md

### DIFF
--- a/docs/getting-started-docker-compose.md
+++ b/docs/getting-started-docker-compose.md
@@ -113,6 +113,12 @@ services:
 
 ## Step 2: Create a Pulsar cluster
 
+To authorize volumes for default uid(10000) in Pulsar dockerfile.
+```bash
+sudo mkdir -p ./data/zookeeper ./data/bookkeeper
+sudo chown 10000 -R data
+```
+
 To create a Pulsar cluster by using the `compose.yml` file, run the following command.
 
 ```bash


### PR DESCRIPTION
<!--

### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

-->

<!-- Either this PR adds a doc for a code PR, -->

This PR adds doc for #[getting-started-docker-compose](https://pulsar.apache.org/docs/next/getting-started-docker-compose/)

<!-- or fixes a doc issue -->

This PR fixes #[getting-started-docker-compose](https://pulsar.apache.org/docs/next/getting-started-docker-compose/)

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

![image](https://github.com/mfdefs/pulsar-site/assets/1729424/86a4789e-5c1d-4977-a963-d7ee5152def1)

